### PR TITLE
Added the KSH Plugin and Fixes for BASH Plugin

### DIFF
--- a/github-sh.plugin.bash
+++ b/github-sh.plugin.bash
@@ -86,7 +86,7 @@ check-function-file() {
     # Get user input about what to do if the file already exists
     _duplicate_file_action=""
     while [ "$_duplicate_file_action" = "" ] ; do
-      read -k 1 "?$_function_file exists! abort, move, replace? [amR]: " _in
+      read -p "$_function_file exists! abort, move, replace? [amR]: " _in
       echo
       if   [ "$_in" = "a" ] || [ "$_in" = "A" ] ; then
         _duplicate_file_action="a"
@@ -105,7 +105,7 @@ check-function-file() {
     if   [ "$_duplicate_file_action" = "a" ] ; then
       _function_file=""
     elif [ "$_duplicate_file_action" = "m" ] ; then
-      read "?Change name to: " _move_name
+      read -p "Change name to: " _move_name
       _move_function_file=$GITHUB_SH_DIR/gh-func-$_move_name
       echo "$_move_name() {" > $_move_function_file
       tail -n +2 $_function_file >> $_move_function_file

--- a/github-sh.plugin.ksh
+++ b/github-sh.plugin.ksh
@@ -1,0 +1,167 @@
+# github
+#
+# Setup For GitHub:
+#   Go to `github.com`
+#   Click your picture in the top right and select "Settings"
+#   Click "Developer Settings" near the bottom on the right
+#   Click "Personal access tokens"
+#   Click the "Generate new token" button in the top right
+#   Confirm your password
+#   Enter a token description (something like "hub in AFS")
+#   Check the following:
+#       [x] repo
+#           [x] repo:status
+#           [x] repo_deployment
+#           [x] public_repo
+#           [x] repo:invite
+#       [x] notifications
+#       [x] user
+#           [x] read:user
+#           [x] user:email
+#           [x] user:follow
+#       [x] write:discussion
+#           [x] read:discussion
+#   Co  py the token value
+#     *****IMPORTANT***** This is the only time you will see this token value!
+#   Run `set-gh-token <your-token> [github-hostname]`
+#       If `github-hostname` is not provided, `$GITHUB_HOST` is used.
+#       If `$GITHUB_HOST` is not set, then `github.com` is used.
+#   User 
+# 
+# Setup For GitHub Enterprise:
+#   Same as GitHub
+
+GITHUB_SH_PLUGIN_DIR=$( cd $(dirname "$0") ; pwd )
+GITHUB_SH_DIR=$HOME/.github-sh
+if ! [ -e $GITHUB_SH_DIR ] ; then
+  mkdir $GITHUB_SH_DIR
+elif ! [ -d $GITHUB_SH_DIR ] ; then
+  echo "$GITHUB_SH_DIR exists and is not a directory, aborting 'source github-sh'"
+  return 1
+fi
+
+# GitHub Token Functions
+tokenfile() {
+  echo "$GITHUB_SH_DIR/$1.token"
+}
+
+set_gh_token() {
+  if [ "$1" = "" ] || [ "$2" = "" ] ; then
+    echo "\
+usage: set_gh_token <token> <hostname>
+  <token>     Your Personal Access Token for <hostname>
+  <hostname>  The github hostname to set the token for i.e. github.com"
+    return 1
+  else
+    echo "$1" | openssl rsautl -encrypt -inkey $HOME/.ssh/id_rsa > $(tokenfile "$2")
+  fi
+}
+
+get_gh_token() {
+  if [ "$1" = "" ] ; then
+    echo "\
+usage: get_gh_token <hostname>
+  <hostname>  The github hostname to get the token for i.e. github.com"
+    return 1
+  else
+    openssl rsautl -decrypt -inkey $HOME/.ssh/id_rsa -in $(tokenfile "$1")
+  fi
+}
+
+# Add a `_gh` command that wraps `hub`
+_gh() {
+  args=("$@")
+  for i in "${!args[@]}" ; do
+    if [ "${args[$i]}" = "pr" ] && [ "${args[$i+1]}" = "create" ] ; then
+      args[$i]="pull-request"
+      args[$i+1]=""
+    fi
+  done
+  # Set github.com as the GitHub host and retrieve your token.
+  # For some stupid reason, you need to set these again in KSH
+  GITHUB_HOST=$GITHUB_HOST GITHUB_TOKEN=$GITHUB_TOKEN hub "${args[@]}"
+}
+
+check_function_file() {
+  if [ -e "$_function_file" ] ; then
+    # Get user input about what to do if the file already exists
+    _duplicate_file_action=""
+    while [ "$_duplicate_file_action" = "" ] ; do
+      read _in?"$_function_file exists! abort, move, replace? [amR]: "
+      echo
+      if   [ "$_in" = "a" ] || [ "$_in" = "A" ] ; then
+        _duplicate_file_action="a"
+      elif [ "$_in" = "m" ] || [ "$_in" = "M" ] ; then
+        _duplicate_file_action="m"
+      elif [ "$_in" = "r" ] || [ "$_in" = "R" ] ; then
+        _duplicate_file_action="r"
+      else
+        echo "Invalid input: options are [a, A, m, M, r, R]"
+      fi
+    done
+    # Do something based on the input:
+    #   a/A: Abort   -> quit
+    #   m/M: Move    -> Change the name of the existing function
+    #   r/R: Replace -> Replace the existing function
+    if   [ "$_duplicate_file_action" = "a" ] ; then
+      _function_file=""
+    elif [ "$_duplicate_file_action" = "m" ] ; then
+      read _move_name?"?Change name to: " 
+      _move_function_file=$GITHUB_SH_DIR/gh-func-$_move_name
+      echo "$_move_name() {" > $_move_function_file
+      tail -n +2 $_function_file >> $_move_function_file
+      source $_move_function_file
+    elif [ "$_duplicate_file_action" = "r" ] ; then
+      # No change, the function will be overwritten naturally.
+      : # Bash Requires a "no-op" character to nop out conditional blocks
+    fi
+  fi
+}
+
+add_gh_host() {
+  if [ "$1" = "" ] || [ "$2" = "" ] ; then
+    echo "\
+usage: add_gh_host <hostname> <alias>
+  <hostname>  The github hostname to add a hub function for i.e. github.com
+  <alias>     The generated function name i.e. gh-pub.  $ gh-pub clone my-repo"
+    return 1
+  else
+    (>/dev/null 2>&1 ping -c 1 "$1")
+    _host_found=$?
+    if [ "$_host_found" = 0 ] ; then
+      _function_file="$GITHUB_SH_DIR/gh-func-$2"
+      # Alert and abort for colliding function names
+      check_function_file
+      # _function_file is set to "" if the user decides to abort
+      if [ "$_function_file" != "" ] ; then
+        # Query for the PAT, if needed
+        if ! [ -e $(tokenfile $1) ] ; then
+          # In KSH, read is backwards
+          read _token?"Personal Access Token ($1): "
+          # Save the PAT, encrypted with an ssh key
+          set_gh_token $_token $1
+        fi
+        # Write and source the new shell function file
+	mkdir -p $(dirname $_function_file)
+        echo "\
+$2() {
+  GITHUB_HOST=$1 GITHUB_TOKEN=\$(get_gh_token $1) _gh \"\$@\"
+}
+$2=hub" > $_function_file
+        source $_function_file
+      fi
+    else
+      echo "Host '$1' not found!"
+    fi
+  fi
+}
+
+# Add the path to this directory to `fpath`
+fpath=($GITHUB_SH_DIR $fpath)
+
+# Source any gh function wrappers (generated by `add_gh_host`)
+for _file in $(ls -a $GITHUB_SH_DIR) ; do
+  if [ "$(echo $_file | cut -c 1-8)" = "gh-func-" ] ; then
+    source $GITHUB_SH_DIR/$_file
+  fi
+done


### PR DESCRIPTION
KSH Plugin was kind've a pain, main differences:
  - KSH doesn't allow '-' in functions, changed to underscores
  - KSH has a really weird read command of the form `var?prompt` 
  - KSH requires env vars are re-declared before calling `hub` 

BASH fixes were for the read command that was missing the `-p` arg. Note, BASH does not support the `-k 1` argument to read. 