### PR TITLE
Added install documentation for ksh and bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,17 @@ source /path/to/github-sh/clone/github-sh.plugin.zsh
 
 ### Installing with `bash`:
 
-TODO: Fill this section in
+Add the following to your `.bashrc`:
+```
+source /path/to/github-sh/clone/github-sh.plugin.bash
+```
+
+### Installing with `ksh`:
+
+Add the following to your `.kshrc`:
+```
+source /path/to/github-sh/clone/github-sh.plugin.ksh
+```
 
 ### Setting up your hub wrappers:
 


### PR DESCRIPTION
This should address #3 

I just added the source command for <shellrc> for both ksh and bash in the instructions, it looks like the token setup and commands are documented later in README